### PR TITLE
Added better error messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.pleo</groupId>
     <artifactId>prop-parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,12 @@
             <version>0.31</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/prop-all/pom.xml
+++ b/prop-all/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>prop-all</artifactId>

--- a/prop-all/src/test/java/io/pleo/prop/PropTest.java
+++ b/prop-all/src/test/java/io/pleo/prop/PropTest.java
@@ -10,7 +10,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
-import org.junit.Before;
 import org.junit.Test;
 
 import io.pleo.prop.archaius.ArchaiusPropFactory;
@@ -34,10 +33,6 @@ import io.pleo.prop.objects.UsesTwiceSameProp;
 import static com.google.common.truth.Truth.*;
 
 public class PropTest {
-
-  @Before
-  public void setup() {
-  }
 
   @Test
   public void can_read_complex_properties() {
@@ -88,11 +83,13 @@ public class PropTest {
     assertThat(complexObjects.getMyComplexObjectProp()).isSameAs(samePropertyAsComplexObjects.getMyComplexObjectProp());
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void cannot_use_twice_same_prop_in_same_object() {
+  @Test
+  public void can_use_twice_same_prop_in_same_object() {
     Injector injector = createInjector(binder -> binder.bind(UsesTwiceSameProp.class));
 
-    injector.getInstance(UsesTwiceSameProp.class);
+    UsesTwiceSameProp samePropTwice = injector.getInstance(UsesTwiceSameProp.class);
+
+    assertThat(samePropTwice.getStringProp1().get()).isEqualTo(samePropTwice.getStringProp2().get());
   }
 
   @Test
@@ -168,7 +165,10 @@ public class PropTest {
     try {
       return Guice.createInjector(allModules);
     } catch (CreationException ex) {
-      throw (RuntimeException) ex.getCause();
+      if (ex.getCause() != null) {
+        throw (RuntimeException) ex.getCause();
+      }
+      throw ex;
     }
   }
 }

--- a/prop-all/src/test/java/io/pleo/prop/objects/UsesTwiceSameProp.java
+++ b/prop-all/src/test/java/io/pleo/prop/objects/UsesTwiceSameProp.java
@@ -6,9 +6,22 @@ import javax.inject.Named;
 import io.pleo.prop.core.Prop;
 
 public class UsesTwiceSameProp {
+  private final Prop<String> stringProp1;
+  private final Prop<String> stringProp2;
+
   @Inject
   public UsesTwiceSameProp(@Named("io.pleo.test.prop3") Prop<String> stringProp1,
                            @Named("io.pleo.test.prop3") Prop<String> stringProp2) {
 
+    this.stringProp1 = stringProp1;
+    this.stringProp2 = stringProp2;
+  }
+
+  public Prop<String> getStringProp1() {
+    return stringProp1;
+  }
+
+  public Prop<String> getStringProp2() {
+    return stringProp2;
   }
 }

--- a/prop-all/src/test/resources/logback.xml
+++ b/prop-all/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration debug="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/prop-archaius/pom.xml
+++ b/prop-archaius/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>prop-archaius</artifactId>

--- a/prop-core/pom.xml
+++ b/prop-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>prop-core</artifactId>

--- a/prop-guice/pom.xml
+++ b/prop-guice/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>prop-guice</artifactId>

--- a/prop-guice/src/main/java/io/pleo/prop/guice/internal/InjectionPointExtractor.java
+++ b/prop-guice/src/main/java/io/pleo/prop/guice/internal/InjectionPointExtractor.java
@@ -10,8 +10,11 @@ import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.LinkedKeyBinding;
 import com.google.inject.spi.ProviderKeyBinding;
 import com.google.inject.spi.UntargettedBinding;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class InjectionPointExtractor extends DefaultBindingTargetVisitor<Object, InjectionPoint> {
+  private static final Logger logger = LoggerFactory.getLogger(InjectionPointExtractor.class);
   private final Predicate<TypeLiteral<?>> filter;
 
   public InjectionPointExtractor(Predicate<TypeLiteral<?>> filter) {
@@ -38,6 +41,7 @@ public class InjectionPointExtractor extends DefaultBindingTargetVisitor<Object,
       try {
         return InjectionPoint.forConstructorOf(key.getTypeLiteral());
       } catch (ConfigurationException e) {
+        logger.info("Skipping key {}: {}", key, e.getMessage());
         return null;
       }
     }

--- a/prop-guice/src/main/java/io/pleo/prop/guice/internal/InjectionPointExtractor.java
+++ b/prop-guice/src/main/java/io/pleo/prop/guice/internal/InjectionPointExtractor.java
@@ -2,6 +2,7 @@ package io.pleo.prop.guice.internal;
 
 import java.util.function.Predicate;
 
+import com.google.inject.ConfigurationException;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.DefaultBindingTargetVisitor;
@@ -34,7 +35,11 @@ public class InjectionPointExtractor extends DefaultBindingTargetVisitor<Object,
 
   private InjectionPoint getInjectionPointForKey(Key<?> key) {
     if (filter.test(key.getTypeLiteral())) {
-      return InjectionPoint.forConstructorOf(key.getTypeLiteral());
+      try {
+        return InjectionPoint.forConstructorOf(key.getTypeLiteral());
+      } catch (ConfigurationException e) {
+        return null;
+      }
     }
 
     return null;

--- a/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropMappingVisitor.java
+++ b/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropMappingVisitor.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import com.google.common.base.Strings;
 import com.google.inject.Binding;
@@ -18,6 +17,8 @@ import com.google.inject.spi.Element;
 import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.PrivateElements;
 import com.google.inject.spi.ProviderLookup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.pleo.prop.core.Prop;
 import io.pleo.prop.core.internal.ParserFactory;
@@ -27,22 +28,26 @@ import io.pleo.prop.core.internal.PropFactory;
  * Goes over every binding and produces a Map associating Guice binding keys to
  * Pleo Prop instances.
  */
-public class PropMappingVisitor extends DefaultElementVisitor<Map<Key<Prop<?>>, Prop<?>>> {
+public class PropMappingVisitor extends DefaultElementVisitor<Map<Key<Prop<?>>, PropResult>> {
+  private static final Logger logger = LoggerFactory.getLogger(PropMappingVisitor.class);
+
   private final InjectionPointExtractor injectionPointExtractor;
   private final PropFactory propFactory;
   private final ParserFactory parserFactory;
 
-  public PropMappingVisitor(Predicate<TypeLiteral<?>> filter, PropFactory propFactory, ParserFactory parserFactory) {
+  public PropMappingVisitor(Predicate<TypeLiteral<?>> filter,
+                            PropFactory propFactory,
+                            ParserFactory parserFactory) {
     this.injectionPointExtractor = new InjectionPointExtractor(filter);
     this.propFactory = propFactory;
     this.parserFactory = parserFactory;
   }
 
-  public Map<Key<Prop<?>>, Prop<?>> visit(Iterable<? extends Element> elements) {
-    Map<Key<Prop<?>>, Prop<?>> mappings = new HashMap<>();
+  public Map<Key<Prop<?>>, PropResult> visit(Iterable<? extends Element> elements) {
+    Map<Key<Prop<?>>, PropResult> mappings = new HashMap<>();
 
     for (Element element : elements) {
-      Map<Key<Prop<?>>, Prop<?>> visitResult = element.acceptVisitor(this);
+      Map<Key<Prop<?>>, PropResult> visitResult = element.acceptVisitor(this);
       // acceptVisitor returns null if the visitor is never called
       if (visitResult != null) {
         // We might encounter duplicates (multiple classes using the same property) but they will be overwritten.
@@ -54,33 +59,42 @@ public class PropMappingVisitor extends DefaultElementVisitor<Map<Key<Prop<?>>, 
   }
 
   @Override
-  public Map<Key<Prop<?>>, Prop<?>> visit(PrivateElements privateElements) {
+  public Map<Key<Prop<?>>, PropResult> visit(PrivateElements privateElements) {
     return visit(privateElements.getElements());
   }
 
   @Override
-  public <T> Map<Key<Prop<?>>, Prop<?>> visit(Binding<T> binding) {
+  public <T> Map<Key<Prop<?>>, PropResult> visit(Binding<T> binding) {
     return extractProps(binding.acceptTargetVisitor(injectionPointExtractor));
   }
 
   @Override
-  public <T> Map<Key<Prop<?>>, Prop<?>> visit(ProviderLookup<T> providerLookup) {
+  public <T> Map<Key<Prop<?>>, PropResult> visit(ProviderLookup<T> providerLookup) {
     return extractProps(providerLookup.getDependency().getInjectionPoint());
   }
 
-  private Map<Key<Prop<?>>, Prop<?>> extractProps(InjectionPoint injectionPoint) {
+  private Map<Key<Prop<?>>, PropResult> extractProps(InjectionPoint injectionPoint) {
     if (injectionPoint == null) {
       return new HashMap<>();
     }
 
-    return injectionPoint
+    Map<Key<Prop<?>>, PropResult> extractedProps = new HashMap<>();
+    injectionPoint
       .getDependencies()
       .stream()
       .map(Dependency::getKey)
       .filter(key -> key.getTypeLiteral().getRawType().equals(Prop.class) &&
                      key.getTypeLiteral().getType() instanceof ParameterizedType)
       .map(key -> (Key<Prop<?>>) key)
-      .collect(Collectors.toMap(Function.identity(), this::keyToProp));
+      .forEach(key -> {
+        try {
+          Prop<?> value = keyToProp(key);
+          extractedProps.put(key, new PropResult(value));
+        } catch (RuntimeException ex) {
+          extractedProps.put(key, new PropResult(ex));
+        }
+      });
+    return extractedProps;
   }
 
   private Prop<?> keyToProp(Key<Prop<?>> key) {

--- a/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropMappingVisitor.java
+++ b/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropMappingVisitor.java
@@ -17,8 +17,6 @@ import com.google.inject.spi.Element;
 import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.PrivateElements;
 import com.google.inject.spi.ProviderLookup;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.pleo.prop.core.Prop;
 import io.pleo.prop.core.internal.ParserFactory;
@@ -29,8 +27,6 @@ import io.pleo.prop.core.internal.PropFactory;
  * Pleo Prop instances.
  */
 public class PropMappingVisitor extends DefaultElementVisitor<Map<Key<Prop<?>>, PropResult>> {
-  private static final Logger logger = LoggerFactory.getLogger(PropMappingVisitor.class);
-
   private final InjectionPointExtractor injectionPointExtractor;
   private final PropFactory propFactory;
   private final ParserFactory parserFactory;

--- a/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropResult.java
+++ b/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropResult.java
@@ -1,0 +1,28 @@
+package io.pleo.prop.guice.internal;
+
+import io.pleo.prop.core.Prop;
+
+public class PropResult {
+  private Prop<?> prop;
+  private Throwable error;
+
+  public PropResult(Prop<?> prop) {
+    this.prop = prop;
+  }
+
+  public PropResult(Throwable error) {
+    this.error = error;
+  }
+
+  public Prop<?> getProp() {
+    return prop;
+  }
+
+  public Throwable getError() {
+    return error;
+  }
+
+  public boolean isError() {
+    return error != null;
+  }
+}

--- a/prop-jackson/pom.xml
+++ b/prop-jackson/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>prop-jackson</artifactId>


### PR DESCRIPTION
`InjectionPoint.forConstructorOf` can throw a `ConfigurationException` if the constructor is not annotated with `@Inject`.

This ConfigurationException causes very verbose and unclear messages because it breaks all of the prop wiring mechanism. This in turn makes it so Guice can't find _any_ Prop instance.

Muting the exception is the right thing to do in this case. Sure, we'll miss some bindings but it doesn't matter because Guice will find this missing `@Inject` annotation before it starts trying to wire stuff and will throw a nice and clean error.

We should probably consider never throwing in the Prop wiring process so errors are found by Guice.