### PR TITLE
Added Java 8 time objects parse methods as known parsers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.pleo</groupId>
     <artifactId>prop-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/prop-all/pom.xml
+++ b/prop-all/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>prop-all</artifactId>

--- a/prop-archaius/pom.xml
+++ b/prop-archaius/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>prop-archaius</artifactId>

--- a/prop-core/pom.xml
+++ b/prop-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>prop-core</artifactId>

--- a/prop-guice/pom.xml
+++ b/prop-guice/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>prop-guice</artifactId>

--- a/prop-jackson/pom.xml
+++ b/prop-jackson/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>prop-jackson</artifactId>

--- a/prop-jackson/src/main/java/io/pleo/prop/jackson/JacksonParserFactory.java
+++ b/prop-jackson/src/main/java/io/pleo/prop/jackson/JacksonParserFactory.java
@@ -5,6 +5,18 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -35,8 +47,21 @@ public class JacksonParserFactory implements ParserFactory {
     knownParsers.put(Float.class, Float::valueOf);
     knownParsers.put(Double.class, Double::valueOf);
     knownParsers.put(BigDecimal.class, BigDecimal::new);
-    knownParsers.put(Duration.class, Duration::parse);
+
     knownParsers.put(Instant.class, Instant::parse);
+    knownParsers.put(OffsetDateTime.class, OffsetDateTime::parse);
+    knownParsers.put(ZonedDateTime.class, ZonedDateTime::parse);
+    knownParsers.put(Duration.class, Duration::parse);
+    knownParsers.put(LocalDateTime.class, LocalDateTime::parse);
+    knownParsers.put(LocalDate.class, LocalDate::parse);
+    knownParsers.put(LocalTime.class, LocalTime::parse);
+    knownParsers.put(MonthDay.class, MonthDay::parse);
+    knownParsers.put(OffsetTime.class, OffsetTime::parse);
+    knownParsers.put(Period.class, Period::parse);
+    knownParsers.put(Year.class, Year::parse);
+    knownParsers.put(YearMonth.class, YearMonth::parse);
+    knownParsers.put(ZoneId.class, ZoneId::of);
+    knownParsers.put(ZoneOffset.class, ZoneOffset::of);
   }
 
   /**


### PR DESCRIPTION
Currently if you have a Prop that is of type `LocalTime` or `LocalDate` (or most java.time objects) you need to put it in double quotes so it gets parsed with the Jackson parser.

Adding explicit known parsers enables simple parsing without quotes.