### PR TITLE
Update Jackson to remove deserialisation vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you're okay with using Guice, Archaius and Jackson, add a dependency on `prop
 <dependency>
     <groupId>io.pleo</groupId>
     <artifactId>prop-all</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.pleo</groupId>
     <artifactId>prop-parent</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/prop-all/pom.xml
+++ b/prop-all/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>prop-all</artifactId>

--- a/prop-archaius/pom.xml
+++ b/prop-archaius/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>prop-archaius</artifactId>

--- a/prop-core/pom.xml
+++ b/prop-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>prop-core</artifactId>

--- a/prop-guice/pom.xml
+++ b/prop-guice/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>prop-guice</artifactId>

--- a/prop-jackson/pom.xml
+++ b/prop-jackson/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.pleo</groupId>
         <artifactId>prop-parent</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1</version>
     </parent>
 
     <artifactId>prop-jackson</artifactId>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.6</version>
+            <version>2.8.10</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
jackson-databind is vulnerable to Deserialization of Untrusted Data ( more info here https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507 ). The mitigation is to update jackson-databind to version 2.8.9 or higher