### PR TITLE
Added the ability to set a @Default value to Prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-
+out/
 .gradle/
 target/
 build/
@@ -8,3 +8,4 @@ build/
 *.patch
 .resourceCache/
 secring.gpg
+*.versionsBackup

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you're okay with using Guice, Archaius and Jackson, add a dependency on `prop
 <dependency>
     <groupId>io.pleo</groupId>
     <artifactId>prop-all</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ allprojects {
     apply plugin: 'maven'
 
     group = 'io.pleo'
-    version = '1.1.3'
+    version = '1.2.0'
 }
 
 subprojects {

--- a/prop-all/src/test/java/io/pleo/prop/PropTest.java
+++ b/prop-all/src/test/java/io/pleo/prop/PropTest.java
@@ -1,5 +1,6 @@
 package io.pleo.prop;
 
+import javax.sql.DataSource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -11,6 +12,7 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import io.pleo.prop.archaius.ArchaiusPropFactory;
 import io.pleo.prop.guice.AutoPropModule;
@@ -26,6 +28,7 @@ import io.pleo.prop.objects.InlineProviderModule;
 import io.pleo.prop.objects.InvalidJSON;
 import io.pleo.prop.objects.MyInterface;
 import io.pleo.prop.objects.MyInterfaceProvider;
+import io.pleo.prop.objects.NoPropObject;
 import io.pleo.prop.objects.NullValue;
 import io.pleo.prop.objects.SamePropertyAsComplexObjects;
 import io.pleo.prop.objects.UnnamedProp;
@@ -54,6 +57,18 @@ public class PropTest {
 
     String stringPropValue = complexObjects.getMyStringProp().get();
     assertThat(stringPropValue).isEqualTo("awp");
+  }
+
+  @Test
+  public void can_bind_non_prop_objects() {
+    DataSource dataSource = Mockito.mock(DataSource.class);
+    Injector injector = createInjector(binder -> {
+      binder.bind(DataSource.class).toInstance(dataSource);
+      binder.bind(NoPropObject.class);
+    });
+
+    NoPropObject object = injector.getInstance(NoPropObject.class);
+    assertThat(object.getDataSource()).isEqualTo(dataSource);
   }
 
   @Test(expected = FailedToCreatePropException.class)

--- a/prop-all/src/test/java/io/pleo/prop/PropTest.java
+++ b/prop-all/src/test/java/io/pleo/prop/PropTest.java
@@ -19,6 +19,7 @@ import io.pleo.prop.guice.internal.JacksonParserFactory;
 import io.pleo.prop.guice.internal.RequiredNamedAnnotationException;
 import io.pleo.prop.objects.BothNamedAnnotations;
 import io.pleo.prop.objects.ComplexObjects;
+import io.pleo.prop.objects.DefaultValue;
 import io.pleo.prop.objects.EmptyNamedAnnotation;
 import io.pleo.prop.objects.InjectedObject;
 import io.pleo.prop.objects.InlineProviderModule;
@@ -62,8 +63,17 @@ public class PropTest {
     injector.getInstance(NullValue.class);
   }
 
+  @Test
+  public void uses_default_value_on_missing_value() {
+    Injector injector = createInjector(binder -> binder.bind(DefaultValue.class));
+
+    DefaultValue defaultValue = injector.getInstance(DefaultValue.class);
+
+    assertThat(defaultValue.getUsesDefaultValue().get()).isEqualTo(DefaultValue.DEFAULT_VALUE);
+  }
+
   @Test(expected = RequiredNamedAnnotationException.class)
-  public void throws_un_unnamed_prop() {
+  public void throws_on_unnamed_prop() {
     Injector injector = createInjector(binder -> binder.bind(UnnamedProp.class));
 
     injector.getInstance(UnnamedProp.class);

--- a/prop-all/src/test/java/io/pleo/prop/PropTest.java
+++ b/prop-all/src/test/java/io/pleo/prop/PropTest.java
@@ -25,6 +25,8 @@ import io.pleo.prop.objects.DefaultValue;
 import io.pleo.prop.objects.EmptyNamedAnnotation;
 import io.pleo.prop.objects.InjectedObject;
 import io.pleo.prop.objects.InlineProviderModule;
+import io.pleo.prop.objects.InvalidDefaultValue;
+import io.pleo.prop.objects.InvalidDefaultValueButValidValue;
 import io.pleo.prop.objects.InvalidJSON;
 import io.pleo.prop.objects.MyInterface;
 import io.pleo.prop.objects.MyInterfaceProvider;
@@ -92,6 +94,20 @@ public class PropTest {
     Injector injector = createInjector(binder -> binder.bind(UnnamedProp.class));
 
     injector.getInstance(UnnamedProp.class);
+  }
+
+  @Test(expected = FailedToCreatePropException.class)
+  public void throws_on_invalid_default_value() {
+    Injector injector = createInjector(binder -> binder.bind(InvalidDefaultValue.class));
+
+    injector.getInstance(InvalidDefaultValue.class);
+  }
+
+  @Test(expected = FailedToCreatePropException.class)
+  public void throws_on_invalid_default_value_even_if_there_is_a_valid_value_in_config() {
+    Injector injector = createInjector(binder -> binder.bind(InvalidDefaultValueButValidValue.class));
+
+    injector.getInstance(InvalidDefaultValueButValidValue.class);
   }
 
   @Test

--- a/prop-all/src/test/java/io/pleo/prop/objects/DefaultValue.java
+++ b/prop-all/src/test/java/io/pleo/prop/objects/DefaultValue.java
@@ -1,0 +1,21 @@
+package io.pleo.prop.objects;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import io.pleo.prop.core.Default;
+import io.pleo.prop.core.Prop;
+
+public class DefaultValue {
+  public static final String DEFAULT_VALUE = "This is the default value!";
+  private Prop<String> usesDefaultValue;
+
+  @Inject
+  public DefaultValue(@Default(DEFAULT_VALUE) @Named("io.pleo.undefined.property") Prop<String> usesDefaultValue) {
+    this.usesDefaultValue = usesDefaultValue;
+  }
+
+  public Prop<String> getUsesDefaultValue() {
+    return usesDefaultValue;
+  }
+}

--- a/prop-all/src/test/java/io/pleo/prop/objects/InvalidDefaultValue.java
+++ b/prop-all/src/test/java/io/pleo/prop/objects/InvalidDefaultValue.java
@@ -1,0 +1,21 @@
+package io.pleo.prop.objects;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import io.pleo.prop.core.Default;
+import io.pleo.prop.core.Prop;
+
+public class InvalidDefaultValue {
+  public static final String DEFAULT_VALUE = "This is not a double!";
+  private Prop<Double> usesDefaultValue;
+
+  @Inject
+  public InvalidDefaultValue(@Default(DEFAULT_VALUE) @Named("io.pleo.undefined.property") Prop<Double> usesDefaultValue) {
+    this.usesDefaultValue = usesDefaultValue;
+  }
+
+  public Prop<Double> getUsesDefaultValue() {
+    return usesDefaultValue;
+  }
+}

--- a/prop-all/src/test/java/io/pleo/prop/objects/InvalidDefaultValueButValidValue.java
+++ b/prop-all/src/test/java/io/pleo/prop/objects/InvalidDefaultValueButValidValue.java
@@ -1,0 +1,21 @@
+package io.pleo.prop.objects;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import io.pleo.prop.core.Default;
+import io.pleo.prop.core.Prop;
+
+public class InvalidDefaultValueButValidValue {
+  public static final String DEFAULT_VALUE = "This is not a double!";
+  private Prop<Double> usesDefaultValue;
+
+  @Inject
+  public InvalidDefaultValueButValidValue(@Default(DEFAULT_VALUE) @Named("io.pleo.test.prop6") Prop<Double> usesDefaultValue) {
+    this.usesDefaultValue = usesDefaultValue;
+  }
+
+  public Prop<Double> getUsesDefaultValue() {
+    return usesDefaultValue;
+  }
+}

--- a/prop-all/src/test/java/io/pleo/prop/objects/NoPropObject.java
+++ b/prop-all/src/test/java/io/pleo/prop/objects/NoPropObject.java
@@ -1,0 +1,17 @@
+package io.pleo.prop.objects;
+
+import javax.inject.Inject;
+import javax.sql.DataSource;
+
+public class NoPropObject {
+  private DataSource dataSource;
+
+  @Inject
+  public NoPropObject(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public DataSource getDataSource() {
+    return dataSource;
+  }
+}

--- a/prop-all/src/test/resources/config.properties
+++ b/prop-all/src/test/resources/config.properties
@@ -3,3 +3,4 @@ io.pleo.test.prop2=[{"name":"dustII", "age":3}, {"name":"inferno", "age":16}]
 io.pleo.test.prop3=awp
 io.pleo.test.prop4=usp
 io.pleo.test.prop5=invalid$!json%}{
+io.pleo.test.prop6=100.00

--- a/prop-archaius/src/main/java/io/pleo/prop/archaius/ArchaiusPropFactory.java
+++ b/prop-archaius/src/main/java/io/pleo/prop/archaius/ArchaiusPropFactory.java
@@ -8,7 +8,7 @@ import io.pleo.prop.core.internal.PropFactory;
 public class ArchaiusPropFactory implements PropFactory {
 
   @Override
-  public <T> Prop<T> createProp(String propName, Function<String, T> parse) {
-    return new ArchaiusProp<>(new ParsingProperty<>(propName, parse));
+  public <T> Prop<T> createProp(String propName, Function<String, T> parse, T defaultValue) {
+    return new ArchaiusProp<>(new ParsingProperty<>(propName, parse, defaultValue));
   }
 }

--- a/prop-archaius/src/main/java/io/pleo/prop/archaius/ParsingProperty.java
+++ b/prop-archaius/src/main/java/io/pleo/prop/archaius/ParsingProperty.java
@@ -12,8 +12,8 @@ public class ParsingProperty<T> extends PropertyWrapper<T> {
   protected final Function<String, T> parser;
   private volatile T value;
 
-  public ParsingProperty(String propName, Function<String, T> parser) {
-    super(propName, null);
+  public ParsingProperty(String propName, Function<String, T> parser, T defaultValue) {
+    super(propName, defaultValue);
     this.parser = parser;
     value = parseProperty();
   }
@@ -22,7 +22,10 @@ public class ParsingProperty<T> extends PropertyWrapper<T> {
     String stringValue = prop.getString();
 
     if (stringValue == null) {
-      throw new UndefinedPropertyException(this);
+      if (defaultValue == null) {
+        throw new UndefinedPropertyException(this);
+      }
+      return defaultValue;
     }
 
     T parsedValue = parser.apply(stringValue);

--- a/prop-archaius/src/test/java/io/pleo/prop/archaius/ParsingPropertyTest.java
+++ b/prop-archaius/src/test/java/io/pleo/prop/archaius/ParsingPropertyTest.java
@@ -28,7 +28,7 @@ public class ParsingPropertyTest {
 
   @Test(expected = UndefinedPropertyException.class)
   public void undefined_property_throws() {
-    new ParsingProperty<>(PROPERTY_KEY, Function.identity());
+    new ParsingProperty<>(PROPERTY_KEY, Function.identity(), null);
   }
 
   @Test
@@ -37,7 +37,7 @@ public class ParsingPropertyTest {
     DynamicConfiguration configuration = new DynamicConfiguration(new TestConfigurationSource(),
                                                                   new FixedDelayPollingScheduler(0, 1, false));
     ((ConcurrentCompositeConfiguration) ConfigurationManager.getConfigInstance()).addConfiguration(configuration);
-    ParsingProperty<String> property = new ParsingProperty(PROPERTY_KEY, Function.identity());
+    ParsingProperty<String> property = new ParsingProperty(PROPERTY_KEY, Function.identity(), null);
 
     assertThat(property.getValue()).isEqualTo("value1");
 

--- a/prop-core/src/main/java/io/pleo/prop/core/Default.java
+++ b/prop-core/src/main/java/io/pleo/prop/core/Default.java
@@ -1,0 +1,14 @@
+package io.pleo.prop.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Retention(RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Default {
+  /** The default value */
+  String value() default "";
+}

--- a/prop-core/src/main/java/io/pleo/prop/core/internal/PropFactory.java
+++ b/prop-core/src/main/java/io/pleo/prop/core/internal/PropFactory.java
@@ -6,5 +6,5 @@ import io.pleo.prop.core.Prop;
 
 @FunctionalInterface
 public interface PropFactory {
-  <T> Prop<T> createProp(String propName, Function<String, T> parse);
+  <T> Prop<T> createProp(String propName, Function<String, T> parse, T defaultValue);
 }

--- a/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropMappingVisitor.java
+++ b/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropMappingVisitor.java
@@ -85,14 +85,18 @@ public class PropMappingVisitor extends DefaultElementVisitor<Map<Key<Prop<?>>, 
     if (injectionPointMember instanceof Executable) {
       List<Parameter> parameters = Arrays.asList(((Executable) injectionPointMember).getParameters());
       for (Dependency<?> dependency : injectionPoint.getDependencies()) {
-        Parameter parameter = parameters.get(dependency.getParameterIndex());
-        PropResult result;
-        try {
-          result = new PropResult(parameterToProp(parameter, dependency.getKey()));
-        } catch (RuntimeException ex) {
-          result = new PropResult(ex);
+        Key<?> key = dependency.getKey();
+        if (key.getTypeLiteral().getRawType().equals(Prop.class) &&
+            key.getTypeLiteral().getType() instanceof ParameterizedType) {
+          Parameter parameter = parameters.get(dependency.getParameterIndex());
+          PropResult result;
+          try {
+            result = new PropResult(parameterToProp(parameter, key));
+          } catch (RuntimeException ex) {
+            result = new PropResult(ex);
+          }
+          extractedProps.put(((Key<Prop<?>>) dependency.getKey()), result);
         }
-        extractedProps.put(((Key<Prop<?>>) dependency.getKey()), result);
       }
     }
 

--- a/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropMappingVisitor.java
+++ b/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropMappingVisitor.java
@@ -1,9 +1,16 @@
 package io.pleo.prop.guice.internal;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Member;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -18,6 +25,7 @@ import com.google.inject.spi.InjectionPoint;
 import com.google.inject.spi.PrivateElements;
 import com.google.inject.spi.ProviderLookup;
 
+import io.pleo.prop.core.Default;
 import io.pleo.prop.core.Prop;
 import io.pleo.prop.core.internal.ParserFactory;
 import io.pleo.prop.core.internal.PropFactory;
@@ -31,9 +39,7 @@ public class PropMappingVisitor extends DefaultElementVisitor<Map<Key<Prop<?>>, 
   private final PropFactory propFactory;
   private final ParserFactory parserFactory;
 
-  public PropMappingVisitor(Predicate<TypeLiteral<?>> filter,
-                            PropFactory propFactory,
-                            ParserFactory parserFactory) {
+  public PropMappingVisitor(Predicate<TypeLiteral<?>> filter, PropFactory propFactory, ParserFactory parserFactory) {
     this.injectionPointExtractor = new InjectionPointExtractor(filter);
     this.propFactory = propFactory;
     this.parserFactory = parserFactory;
@@ -75,51 +81,115 @@ public class PropMappingVisitor extends DefaultElementVisitor<Map<Key<Prop<?>>, 
     }
 
     Map<Key<Prop<?>>, PropResult> extractedProps = new HashMap<>();
-    injectionPoint
-      .getDependencies()
-      .stream()
-      .map(Dependency::getKey)
-      .filter(key -> key.getTypeLiteral().getRawType().equals(Prop.class) &&
-                     key.getTypeLiteral().getType() instanceof ParameterizedType)
-      .map(key -> (Key<Prop<?>>) key)
-      .forEach(key -> {
+    Member injectionPointMember = injectionPoint.getMember();
+    if (injectionPointMember instanceof Executable) {
+      List<Parameter> parameters = Arrays.asList(((Executable) injectionPointMember).getParameters());
+      for (Dependency<?> dependency : injectionPoint.getDependencies()) {
+        Parameter parameter = parameters.get(dependency.getParameterIndex());
+        PropResult result;
         try {
-          Prop<?> value = keyToProp(key);
-          extractedProps.put(key, new PropResult(value));
+          result = new PropResult(parameterToProp(parameter, dependency.getKey()));
         } catch (RuntimeException ex) {
-          extractedProps.put(key, new PropResult(ex));
+          result = new PropResult(ex);
         }
-      });
+        extractedProps.put(((Key<Prop<?>>) dependency.getKey()), result);
+      }
+    }
+
+    // TODO - GSIMARD: Remove commented code
+    //    injectionPoint
+    //      .getDependencies()
+    //      .stream()
+    //      .map(Dependency::getKey)
+    //      .filter(key -> key.getTypeLiteral().getRawType().equals(Prop.class) &&
+    //                     key.getTypeLiteral().getType() instanceof ParameterizedType)
+    //      .map(key -> (Key<Prop<?>>) key)
+    //      .forEach(key -> {
+    //        try {
+    //          Prop<?> value = keyToProp(key);
+    //          extractedProps.put(key, new PropResult(value));
+    //        } catch (RuntimeException ex) {
+    //          extractedProps.put(key, new PropResult(ex));
+    //        }
+    //      });
     return extractedProps;
   }
 
-  private Prop<?> keyToProp(Key<Prop<?>> key) {
-    String propertyName = getNamedAnnotationValue(key);
+  private Prop<?> parameterToProp(Parameter parameter, Key key) {
+    String propertyName = getNamedAnnotationValue(Arrays.asList(parameter.getAnnotations()), key);
 
-    Type type = ((ParameterizedType) key.getTypeLiteral().getType()).getActualTypeArguments()[0];
+    Type type = ((ParameterizedType) parameter.getParameterizedType()).getActualTypeArguments()[0];
     Function<String, Object> parser = parserFactory.createParserForType(type);
 
     try {
-      return propFactory.createProp(propertyName, parser);
+      Object defaultValue = Optional
+        .ofNullable(parameter.getAnnotation(Default.class))
+        .map(Default::value)
+        .map(parser::apply)
+        .orElse(null);
+      return propFactory.createProp(propertyName, parser, defaultValue);
     } catch (RuntimeException ex) {
       throw new FailedToCreatePropException(propertyName, ex);
     }
   }
 
-  private static String getNamedAnnotationValue(Key<Prop<?>> key) {
+  //  private Prop<?> keyToProp(Key<Prop<?>> key) {
+  //    String propertyName = getNamedAnnotationValue(key);
+  //
+  //    Type type = ((ParameterizedType) key.getTypeLiteral().getType()).getActualTypeArguments()[0];
+  //    Function<String, Object> parser = parserFactory.createParserForType(type);
+  //
+  //    String rawDefaultValue = getDefaultAnnotationValue(key);
+  //    try {
+  //      Object defaultValue = rawDefaultValue == null ? null : parser.apply(rawDefaultValue);
+  //      return propFactory.createProp(propertyName, parser, defaultValue);
+  //    } catch (RuntimeException ex) {
+  //      throw new FailedToCreatePropException(propertyName, ex);
+  //    }
+  //  }
+  //
+  //  private static String getNamedAnnotationValue(Key<Prop<?>> key) {
+  //    String propName = null;
+  //
+  //    // Both javax.inject.Named and com.google.inject.name.Named can be used with Guice.
+  //    if (key.getAnnotation() instanceof javax.inject.Named) {
+  //      propName = ((javax.inject.Named) key.getAnnotation()).value();
+  //    } else if (key.getAnnotation() instanceof com.google.inject.name.Named) {
+  //      propName = ((com.google.inject.name.Named) key.getAnnotation()).value();
+  //    }
+  //
+  //    if (Strings.isNullOrEmpty(propName)) {
+  //      throw new RequiredNamedAnnotationException(key);
+  //    }
+  //
+  //    return propName;
+  //  }
+
+  private static String getNamedAnnotationValue(List<Annotation> annotations, Key key) {
     String propName = null;
 
-    // Both javax.inject.Named and com.google.inject.name.Named can be used with Guice.
-    if (key.getAnnotation() instanceof javax.inject.Named) {
-      propName = ((javax.inject.Named) key.getAnnotation()).value();
-    } else if (key.getAnnotation() instanceof com.google.inject.name.Named) {
-      propName = ((com.google.inject.name.Named) key.getAnnotation()).value();
+    // TODO - GSIMARD: Rework with filter and findFirst
+    for (Annotation annotation : annotations) {
+      // Both javax.inject.Named and com.google.inject.name.Named can be used with Guice.
+      if (annotation instanceof javax.inject.Named) {
+        propName = ((javax.inject.Named) annotation).value();
+      } else if (annotation instanceof com.google.inject.name.Named) {
+        propName = ((com.google.inject.name.Named) annotation).value();
+      }
     }
 
     if (Strings.isNullOrEmpty(propName)) {
       throw new RequiredNamedAnnotationException(key);
     }
-
     return propName;
+  }
+
+  private static String getDefaultAnnotationValue(List<Annotation> annotations) {
+    for (Annotation annotation : annotations) {
+      if (annotations instanceof Default) {
+        return Strings.emptyToNull(((Default) annotation).value());
+      }
+    }
+    return null;
   }
 }

--- a/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropParameters.java
+++ b/prop-guice/src/main/java/io/pleo/prop/guice/internal/PropParameters.java
@@ -1,0 +1,24 @@
+package io.pleo.prop.guice.internal;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+import com.google.inject.TypeLiteral;
+
+public class PropParameters<T> {
+  private TypeLiteral<T> typeLiteral;
+  private List<Annotation> annotations;
+
+  public PropParameters(TypeLiteral<T> typeLiteral, List<Annotation> annotations) {
+    this.typeLiteral = typeLiteral;
+    this.annotations = annotations;
+  }
+
+  public TypeLiteral<T> getTypeLiteral() {
+    return typeLiteral;
+  }
+
+  public List<Annotation> getAnnotations() {
+    return annotations;
+  }
+}


### PR DESCRIPTION
I had to rework a few things since the `Key` object in Guice only lets me access `@Named` annotation values, not arbitrary annotations (it's more complicated then that but you get the idea).

So now it uses the notion of a `Parameter` (from java.reflect) to get the `@Default` annotation values.

I'm happy with the results. The library is well covered by UTs and they all pass. I added one for default values. Overall I'm quite confident I didn't break anything 🤞 

