### PR TITLE
Don't log property values on change 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ allprojects {
     apply plugin: 'maven'
 
     group = 'io.pleo'
-    version = '1.3.1'
+    version = '1.3.2'
 }
 
 subprojects {

--- a/prop-archaius/src/main/java/io/pleo/prop/archaius/ParsingProperty.java
+++ b/prop-archaius/src/main/java/io/pleo/prop/archaius/ParsingProperty.java
@@ -42,13 +42,11 @@ public class ParsingProperty<T> extends PropertyWrapper<T> {
     try {
       T newValue = parseProperty();
       propertyChanged(getValue());
-      logger.info("Property '{}' changed from '{}' to '{}'.", getName(), value, newValue);
+      logger.info("Property '{}' changed.", getName());
       value = newValue;
     } catch (RuntimeException ex) {
-      logger.warn("Failed to parse property '{}' with value '{}'. Keeping last valid value of '{}'.",
+      logger.warn("Failed to parse property '{}'. Keeping last valid value.",
                   getName(),
-                  prop.getString(),
-                  value,
                   ex);
     }
   }


### PR DESCRIPTION
The library currently logs the values of properties when these change. This may lead to secret properties leaking to logs. This PR is a simple fix to omit the values and only log the name of the property that changed. 

A more general solution would be to add attributes to denote properties as public vs. private. This however would require a more extensive update.

For this PR, the utility trade-off is relatively small -- we still get a record of a property changing. The security advantage on the other hand is high -- especially in the case of updating secret keys where both the old key and new key would be logged.
 