### PR TITLE
fix(build workflow): allow publishing to issues

### DIFF
--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   build-n-publish:
-    runs-on: [self-hosted, universal]
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
-    
+
     permissions:
       # Allows cloning repo and creating releases in the release page
       contents: write
@@ -16,9 +16,8 @@ jobs:
       issues: read
       # Allows search through PRs and issues as well as commenting on PRs
       pull-requests: write
-    
-    steps:
 
+    steps:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
@@ -38,7 +37,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 17
-          distribution: 'adopt'
+          distribution: "adopt"
 
       - name: Gradle Build
         uses: burrunan/gradle-cache-action@v1.10
@@ -51,7 +50,7 @@ jobs:
       - name: Setup Node.js, latest LTS
         uses: actions/setup-node@v2
         with:
-          node-version: 'lts/*'
+          node-version: "lts/*"
 
       - name: Setup Semantic Release dependencies
         run: >


### PR DESCRIPTION
Looking at the most recent failed action, it appears that we haven't supplied the appropriate permissions for the GITHUB_TOKEN we're using for publishing: 
https://github.com/pleo-io/prop/runs/4895790927?check_suite_focus=true

Interesting bit in the error where we see it's trying to post to issues:
```    
data: {
      message: 'Resource not accessible by integration',
      documentation_url: 'https://docs.github.com/rest/reference/issues#create-an-issue'
    }
  },
  request: {
    method: 'POST',
    url: 'https://api.github.com/repos/pleo-io/prop/issues',
    headers: {
      accept: 'application/vnd.github.v3+json',
      'user-agent': 'octokit-rest.js/18.12.0 octokit-core.js/3.5.1 Node.js/17.4.0 (linux; x64)',
      authorization: 'token [REDACTED]',
      'content-type': 'application/json; charset=utf-8'
    }
```

Additionally, we shouldn't migrate this to self-hosted runners. It's  public repo, so our IP allowlist won't be enforced here unless we're trying to access private packages, which I assume we shouldn't be doing on a public repo. Read more about self-hosted runner security here: https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners#self-hosted-runner-security

