### PR TITLE
[DEVX-2447] Rollout new renovate process

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "semanticCommitType": "fix",
   "extends": [
-    "local>pleo-io/renovate-config"
+    "github>pleo-io/renovate-config:default.json5"
   ]
 }

--- a/.github/templates.yaml
+++ b/.github/templates.yaml
@@ -1,18 +1,16 @@
 version: v34.10.1
+
 files:
-  - .autorc.json
-  - .github/.kodiak.toml
   - .github/workflows/build-and-test.yaml
   - .github/workflows/codeql-analysis.yaml
   - .github/workflows/pr-help.yaml
   - .github/workflows/release.yaml
   - .github/workflows/renovate_dependency_management.yaml
+  - .autorc.json
+  - .github/.kodiak.toml
+
 values:
-  autoRelease: true
-  allowKodiakAutoMerge: true
-  defaultBranch: main
   sendOpsLevelDeployNotifications: true
-  sendOpsLevelVulnerabilityCheck: true
   deploymentEnabled: false
   runWizCliDepsScan: false
   renovateCronjobSchedule: '25 6 * * 1-5' # This is UTC -> At 07:25 CET / 08:25 CEST on every day-of-week from Monday through Friday.

--- a/.github/templates.yaml
+++ b/.github/templates.yaml
@@ -1,5 +1,4 @@
-version: v34.9.2
-
+version: v34.10.1
 files:
   - .autorc.json
   - .github/.kodiak.toml
@@ -8,7 +7,6 @@ files:
   - .github/workflows/pr-help.yaml
   - .github/workflows/release.yaml
   - .github/workflows/renovate_dependency_management.yaml
-
 values:
   autoRelease: true
   allowKodiakAutoMerge: true


### PR DESCRIPTION
This PR includes all the necessary changes for this repository to use the new Renovate setup. With this new setup, you'll get the following:
* Shorten cycle time for pull requests. Thanks to enabling merge queues.
* Full control over when Renovate runs for your repo. It now runs as a scheduled (or on-demand) GH workflow on your repo.

And now, the details about the changes on this PR:
* Add the renovate_dependency_management.yaml GH workflow, which will run Renovate for this repo at a schedule, or on demand (for this we also need to bump to a recent centralized-templates version).
* Add the schedule of when Renovate will run for your repo. Our proposal is to run it once in the morning from Mon-Fri, but you can tweak it if needed.
* Remove grouping for minor and patch dependencies. With the optimized Renovate setup, where cycle time for Renovate PRs is much shorter, we don't see a need for it. Additionally, it was causing problems as some repos ended up with failing PRs that bundled dozens of dependencies, and troubleshooting them was a nightmare.
* For the repos where only 1 code reviewer approval is needed, we remove the unnecessary Kodiak setup.
* Point to the default.json5 Renovate global preset in renovate-config repo.
* Rename Renovate config from .json to .json5, so you can add explanatory comment to any custom config you need for your repo
* Clean up of the repo custom Renovate config, by removing entries that are not needed, or already present in the global Renovate preset in renovate-config.

Apart from these changes, over the next couple days, we will take care of enabling merge queues for this repo.
If you are concerned about any changes, please comment here or reach out to
[#ask-devx](https://getpleo.slack.com/archives/C030H8BMU8K).
