### PR TITLE
PEG-5292: Github automated teams migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo.
 # Unless a later match takes precedence, they will be requested for review when someone opens a pull request.
-* @pleo-io/pegasus-backend
+* @pleo-io/team-invoices

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This document describes some processes and guidelines we follow as a team and wi
 
 When creating your PR, please add the following reviewers:
 
-- `@pleo-io/pegasus-backend` or individual members of your team
+- `@pleo-io/team-invoices` or individual members of your team
 
 Keep the number of reviewers small to make it obvious who is responsible for reviewing the PR.
 

--- a/opslevel.yml
+++ b/opslevel.yml
@@ -3,7 +3,7 @@ version: 1
 service:
   name: Prop
   lifecycle: generally_available
-  owner: pegasus
+  owner: team-invoices
   language: Kotlin
   description: |-
     Simple auto-discovered dynamic properties for your app!


### PR DESCRIPTION
Changes the team name to match the automated github team names