### PR TITLE
docs: remove grim reaper note from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,3 @@
-> :warning: This repository was archived automatically since no ownership was defined :warning:
->
-> For details on how to claim stewardship of this repository see:
->
-> [How to configure a service in OpsLevel](https://www.notion.so/pleo/How-to-configure-a-service-in-OpsLevel-f6483fcb4fdd4dcc9fc32b7dfe14c262)
->
-> To learn more about the automatic process for stewardship which archived this repository see:
->
-> [Automatic process for stewardship](https://www.notion.so/pleo/Automatic-process-for-stewardship-43d9def9bc9a4010aba27144ef31e0f2)
-
-> :warning: This repository was archived automatically since no ownership was defined :warning:
->
-> For details on how to claim stewardship of this repository see:
->
-> [How to configure a service in OpsLevel](https://www.notion.so/pleo/How-to-configure-a-service-in-OpsLevel-f6483fcb4fdd4dcc9fc32b7dfe14c262)
->
-> To learn more about the automatic process for stewardship which archived this repository see:
->
-> [Automatic process for stewardship](https://www.notion.so/pleo/Automatic-process-for-stewardship-43d9def9bc9a4010aba27144ef31e0f2)
-
 # Prop 
 
 Pleo prop is a dynamic property library. It allows you to configure your application using properties that are not hardcoded and can be easily modified at runtime.

--- a/opslevel.yml
+++ b/opslevel.yml
@@ -3,7 +3,7 @@ version: 1
 service:
   name: Prop
   lifecycle: generally_available
-  owner: pegasus
+  owner: team-invoices
   language: Kotlin
   description: |-
     Simple auto-discovered dynamic properties for your app!


### PR DESCRIPTION
The repo was archived because the configured owner in this repo did not match the team name.

Removing the note in the readme.
